### PR TITLE
Add support of dart2-api template.

### DIFF
--- a/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
+++ b/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
@@ -18,7 +18,7 @@ class Openapi {
   /// -t
   final String templateDirectory;
 
-  /// Generator to use (dart|dart-jaguar|dart-dio)
+  /// Generator to use (dart|dart2-api|dart-jaguar|dart-dio)
   ///
   /// -g, --generator-name
   final String generatorName;

--- a/openapi-generator-cli/.gitignore
+++ b/openapi-generator-cli/.gitignore
@@ -164,3 +164,5 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 .idea/**
+
+target

--- a/openapi-generator-cli/pom.xml
+++ b/openapi-generator-cli/pom.xml
@@ -1,0 +1,62 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>openpitools</groupId>
+    <artifactId>openapi-generator-patched</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.8</version>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                  <mainClass>org.openapitools.codegen.OpenAPIGenerator</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                              <filter>
+                                <artifact>com.bluetrainsoftware.maven:openapi-dart-generator</artifact>
+                                <excludes>
+                                    <exclude>META-INF/MANIFEST.MF</exclude>
+                                </excludes>
+                              </filter>
+                            </filters>
+                            <outputFile>${basedir}/lib/openapi-generator.jar</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator-cli</artifactId>
+            <version>4.3.1</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.bluetrainsoftware.maven</groupId>
+            <artifactId>openapi-dart-generator</artifactId>
+            <version>3.6</version>
+        </dependency>        
+    </dependencies>
+</project>
+
+

--- a/openapi-generator/lib/src/openapi_generator_runner.dart
+++ b/openapi-generator/lib/src/openapi_generator_runner.dart
@@ -49,9 +49,10 @@ class OpenapiGenerator extends GeneratorForAnnotation<Openapi> {
         _readFieldValueAsString(annotation, 'generatorName', 'dart');
     if (generator != 'dart' &&
         generator != 'dart-dio' &&
+        generator != 'dart2-api' &&
         generator != 'dart-jaguar') {
       throw InvalidGenerationSourceError(
-        'Generator name must be any of dart, dart-dio, dart-jaguar.',
+        'Generator name must be any of dart, dart2-api, dart-dio, dart-jaguar.',
       );
     }
     command = '$command$separator-g$separator$generator';


### PR DESCRIPTION
It contains a pom.xml also which can recreate the patched JAR file. So any new template can be added to openapi-genereator easy with this method.