### PR TITLE
Add missing pubName to Dio and Jaguar properties

### DIFF
--- a/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
+++ b/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
@@ -168,6 +168,7 @@ class JaguarProperties extends AdditionalProperties {
             pubAuthorEmail: pubAuthorEmail,
             pubDescription: pubDescription,
             pubHomepage: pubHomepage,
+            pubName: pubName,
             pubVersion: pubVersion,
             sortModelPropertiesByRequiredFlag:
                 sortModelPropertiesByRequiredFlag,
@@ -207,6 +208,7 @@ class DioProperties extends AdditionalProperties {
             pubAuthorEmail: pubAuthorEmail,
             pubDescription: pubDescription,
             pubHomepage: pubHomepage,
+            pubName: pubName,
             pubVersion: pubVersion,
             sortModelPropertiesByRequiredFlag:
                 sortModelPropertiesByRequiredFlag,


### PR DESCRIPTION
Hi!
First of all - thanks for great package! 
Although I've found small bug - `pubName` parameter was ignored in both `DioProperties` and `JaguarProperties` classes. This MR fixes it. 