### PR TITLE
Option to use flutter wrapper - fvm or flutterw

### DIFF
--- a/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
+++ b/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
@@ -119,6 +119,9 @@ class AdditionalProperties {
   /// Allow the 'x-enum-values' extension for enums
   final bool useEnumExtension;
 
+  /// Flutter wrapper to use (none|flutterw|fvm)
+  final Wrapper wrapper;
+
   const AdditionalProperties(
       {this.allowUnicodeIdentifiers = false,
       this.ensureUniqueParams = true,
@@ -132,7 +135,8 @@ class AdditionalProperties {
       this.pubVersion,
       this.sortModelPropertiesByRequiredFlag = true,
       this.sortParamsByRequiredFlag = true,
-      this.sourceFolder});
+      this.sourceFolder,
+      this.wrapper = Wrapper.none});
 }
 
 class JaguarProperties extends AdditionalProperties {
@@ -220,3 +224,4 @@ enum SerializationFormat { JSON, PROTO }
 
 /// The name of the generator to use
 enum Generator { DART, DART_DIO, DART2_API, DART_JAGUAR }
+enum Wrapper {fvm, flutterw, none}

--- a/openapi-generator-annotations/pubspec.yaml
+++ b/openapi-generator-annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator_annotations
 description: Annotation package for openapi_generator https://pub.dev/packages/openapi_generator.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 

--- a/openapi-generator-cli/pubspec.yaml
+++ b/openapi-generator-cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator_cli
 description: A dart wrapper around openapi-generator inspired by the node implementation.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 environment:

--- a/openapi-generator/lib/src/openapi_generator_runner.dart
+++ b/openapi-generator/lib/src/openapi_generator_runner.dart
@@ -262,7 +262,7 @@ class OpenapiGenerator extends GeneratorForAnnotation<annots.Openapi> {
   }
 
   Command _getCommandWithWrapper(String command, List<String> arguments, ConstantReader annotation){
-    final wrapper = _readFieldValueAsEnum<annots.Wrapper>(annotation, 'wrapper', annots.Wrapper.none);
+    final wrapper = annotation.read('additionalProperties')?.read('wrapper')?.enumValue<annots.Wrapper>() ?? annots.Wrapper.none;
     switch(wrapper){
       case annots.Wrapper.flutterw:
         return Command('./flutterw', arguments);
@@ -272,13 +272,6 @@ class OpenapiGenerator extends GeneratorForAnnotation<annots.Openapi> {
       default:
         return Command(command, arguments);
     }
-  }
-
-  T _readFieldValueAsEnum<T>(ConstantReader annotation, String fieldName,
-      [T defaultValue]) {
-    var reader = annotation.read(fieldName);
-
-    return reader.isNull ? defaultValue : reader.enumValue<T>() ?? defaultValue;
   }
 
   String _readFieldValueAsString(ConstantReader annotation, String fieldName,

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator
 description: Generator for openapi client sdk inspired by the npm impplementation of openapi-generator-cli.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 environment:
@@ -10,9 +10,9 @@ dependencies:
   build: '>=1.3.0 <=1.10.3'
   source_gen: ^0.9.10+1
   path: ^1.7.0
-  openapi_generator_annotations: ^2.0.0
+  openapi_generator_annotations: ^2.1.0
   analyzer: '>=0.40.0 <=0.41.1'
-  openapi_generator_cli: ^2.0.0
+  openapi_generator_cli: ^2.1.0
 
 dev_dependencies:
   pedantic: ^1.9.2


### PR DESCRIPTION
A lot of people uses some kind of wrapper for flutter. In the past I have used [flutter_wrapper](https://github.com/passsy/flutter_wrapper) and recently I've switched to [fvm](https://github.com/leoafarias/fvm). 

Currently this library does not support any wrapper, so I've decided to add one option which allows user to choose between fvm or flutterw (or none, which is default option). 