### PR TITLE
Update analyzer constraints

### DIFF
--- a/openapi-generator-annotations/test/openapi_generator_annotations_test.dart
+++ b/openapi-generator-annotations/test/openapi_generator_annotations_test.dart
@@ -1,4 +1,3 @@
-import 'package:openapi_generator_annotations/openapi_generator_annotations.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/openapi-generator-cli/bin/main.dart
+++ b/openapi-generator-cli/bin/main.dart
@@ -12,7 +12,7 @@ void main(List<String> arguments) async {
 
   var commands = [
     '-jar',
-    "${"${binPath}"}",
+    "${"$binPath"}",
     ...arguments,
   ];
   if (JAVA_OPTS.isNotEmpty) {

--- a/openapi-generator/CHANGELOG.md
+++ b/openapi-generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.1
+
+- Update the _analyzer_ constraint
+
 ## 3.3.0+1
 
 - Bumped dart-ogurets (_dioAlt_) generator to 5.11

--- a/openapi-generator/lib/src/openapi_generator_runner.dart
+++ b/openapi-generator/lib/src/openapi_generator_runner.dart
@@ -76,7 +76,7 @@ class OpenapiGenerator extends GeneratorForAnnotation<annots.Openapi> {
 
       var arguments = [
         '-jar',
-        "${"${binPath}"}",
+        "${"$binPath"}",
         ...command.split(separator).toList(),
       ];
       if (JAVA_OPTS.isNotEmpty) {

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator
 description: Generator for openapi client sdk inspired by the npm implementation of openapi-generator-cli.
-version: 3.3.0+1
+version: 3.3.1
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 environment:

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   source_gen: '>=1.0.0 <=2.0.0'
   path: '>=1.0.0 <=2.0.0'
   openapi_generator_annotations: ^3.3.0
-  analyzer: '>=1.4.0 <=3.0.0'
+  analyzer: '>=1.4.0 <=5.0.0'
   openapi_generator_cli: ^3.3.0
 
 dev_dependencies:


### PR DESCRIPTION
First of all thank you for your work, the package is really helpful!

The current analyzer constraint (`<=3.0.0`) of `openapi_generator` is restricting us from upgrading the dependencies of the project we are working on.

With this pull request I aim to remedy that.