### PR TITLE
Fix enum value retrieval error

### DIFF
--- a/openapi-generator/CHANGELOG.md
+++ b/openapi-generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.2
+
+- Fix the enum value retrieval error
+
 ## 3.3.1
 
 - Update the _analyzer_ constraint

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator
 description: Generator for openapi client sdk inspired by the npm implementation of openapi-generator-cli.
-version: 3.3.1
+version: 3.3.2
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 environment:


### PR DESCRIPTION
Looks like with https://github.com/gibahjoe/openapi-generator-dart/pull/71 I broke something: https://github.com/gibahjoe/openapi-generator-dart/issues/73.

Hopefully this pull request will fix that and close both https://github.com/gibahjoe/openapi-generator-dart/issues/73 and https://github.com/gibahjoe/openapi-generator-dart/issues/72:
added a check to make sure that the enum is always the specified type and replaced the enum value parsing with a different one.