### PR TITLE
Fix enum value retrieval error and update the generator CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 doc/api/
 .idea/vcs.xml
 .idea/
+
+# macOS
+.DS_Store

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,7 +13,7 @@ void main() {
     typeMappings: {
       'Pet': 'ExamplePet'
     },
-    generatorName: Generator.dioNext,
+    generatorName: Generator.dio,
     outputDirectory: 'api/petstore_api')
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);

--- a/openapi-generator-annotations/CHANGELOG.md
+++ b/openapi-generator-annotations/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0
+
+- **BREAKING CHANGES**
+  - `dioNext` and `jaguar` generators are removed
+
+- Bumped dart-ogurets (_dioAlt_) generator to 5.13
+  with [changes](https://github.com/dart-ogurets/dart-openapi-maven#changelog)
+- Bumped official openapi generator to 6.0.0.
+  See [change log](https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.0.0)
+
 ## 3.3.0
 
 - Bumped dart-ogurets (_dioAlt_) generator to 5.11

--- a/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
+++ b/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
@@ -337,17 +337,5 @@ enum Generator {
   ///
   /// You can read more about it here https://github.com/dart-ogurets/dart-openapi-maven
   dioAlt,
-
-  /// This uses the next gen dio generator. This is experimental and use at your own risk. It might be removed or renamed in the future
-  ///
-  /// You can read more about it here https://github.com/OpenAPITools/openapi-generator/pull/8869
-  dioNext,
-
-  /// This generates code based on the jaguar package Source gen is required
-  /// after generating code with this generator
-  /// corresponds to dart-jaguar
-  ///
-  /// An Http Api generator inspired by Retrofit for Dart
-  jaguar,
 }
 enum Wrapper { fvm, flutterw, none }

--- a/openapi-generator-annotations/pubspec.yaml
+++ b/openapi-generator-annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator_annotations
 description: Annotation package for openapi_generator https://pub.dev/packages/openapi_generator.
-version: 3.3.0
+version: 4.0.0
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 

--- a/openapi-generator/CHANGELOG.md
+++ b/openapi-generator/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0
+
+- **BREAKING CHANGES**
+  - `dioNext` and `jaguar` generators are removed
+
+- Bumped dart-ogurets (_dioAlt_) generator to 5.13
+  with [changes](https://github.com/dart-ogurets/dart-openapi-maven#changelog)
+- Bumped official openapi generator to 6.0.0.
+  See [change log](https://github.com/OpenAPITools/openapi-generator/releases/tag/v6.0.0)
+
 ## 3.3.2
 
 - Fix the enum value retrieval error

--- a/openapi-generator/CHANGELOG.md
+++ b/openapi-generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.2
+
+- Fix the enum value retrieval error
+
 ## 3.3.1
 
 - Update the _analyzer_ constraint

--- a/openapi-generator/lib/src/openapi_generator_runner.dart
+++ b/openapi-generator/lib/src/openapi_generator_runner.dart
@@ -131,8 +131,6 @@ class OpenapiGenerator extends GeneratorForAnnotation<annots.Openapi> {
                 'OpenapiGenerator :: skipping source gen because generator does not need it ::');
             break;
           case annots.Generator.dio:
-          case annots.Generator.dioNext:
-          case annots.Generator.jaguar:
           case annots.Generator.dioAlt:
             try {
               var runnerOutput =
@@ -226,14 +224,8 @@ class OpenapiGenerator extends GeneratorForAnnotation<annots.Openapi> {
       case annots.Generator.dio:
         genName = 'dart-dio';
         break;
-      case annots.Generator.dioNext:
-        genName = 'dart-dio-next';
-        break;
       case annots.Generator.dioAlt:
         genName = 'dart2-api';
-        break;
-      case annots.Generator.jaguar:
-        genName = 'dart-jaguar';
         break;
       default:
         throw InvalidGenerationSourceError(

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   path: '>=1.0.0 <=2.0.0'
   openapi_generator_annotations: ^3.3.0
   analyzer: '>=1.4.0 <=5.0.0'
-  openapi_generator_cli: ^3.3.0
+  openapi_generator_cli: ^4.0.0
 
 dev_dependencies:
   pedantic:

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator
 description: Generator for openapi client sdk inspired by the npm implementation of openapi-generator-cli.
-version: 3.3.1
+version: 3.3.2
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 environment:

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openapi_generator
 description: Generator for openapi client sdk inspired by the npm implementation of openapi-generator-cli.
-version: 3.3.2
+version: 4.0.0
 homepage: https://github.com/gibahjoe/openapi-generator-dart
 
 environment:

--- a/openapi-generator/pubspec.yaml
+++ b/openapi-generator/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   build: '>=0.12.6 <=3.0.0'
   source_gen: '>=1.0.0 <=2.0.0'
   path: '>=1.0.0 <=2.0.0'
-  openapi_generator_annotations: ^3.3.0
+  openapi_generator_annotations: ^4.0.0
   analyzer: '>=1.4.0 <=5.0.0'
   openapi_generator_cli: ^4.0.0
 


### PR DESCRIPTION
Updates the embedded CLI version and removes the deprecated generators on top of #74.
Created a different pull request in case the fix is okay but there are issues with the removals.

With https://github.com/gibahjoe/openapi-generator-dart/pull/71 something broke: https://github.com/gibahjoe/openapi-generator-dart/issues/73.

Hopefully this pull request will fix that and close both https://github.com/gibahjoe/openapi-generator-dart/issues/73 and https://github.com/gibahjoe/openapi-generator-dart/issues/72:
added a check to make sure that the enum is always the specified type and replaced the enum value parsing with a different one.
