### PR TITLE
Add updateAnnotatedFile property

### DIFF
--- a/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
+++ b/openapi-generator-annotations/lib/src/openapi_generator_annotations_base.dart
@@ -111,6 +111,10 @@ class Openapi {
   /// Include in depth logging output from run commands.
   final bool debugLogging;
 
+  /// If set to true, the annotated file will be added or updated comment lines as of the last run date on the top of the file.
+  /// Defaults to true
+  final bool updateAnnotatedFile;
+
   const Openapi({
     this.additionalProperties,
     this.skipSpecValidation = false,
@@ -129,6 +133,7 @@ class Openapi {
     this.cachePath,
     this.projectPubspecPath,
     this.debugLogging = false,
+    this.updateAnnotatedFile = true,
   });
 }
 

--- a/openapi-generator-annotations/test/openapi_generator_annotations_test.dart
+++ b/openapi-generator-annotations/test/openapi_generator_annotations_test.dart
@@ -51,6 +51,13 @@ void main() {
             debugLogging: true);
         expect(api.debugLogging, isTrue);
       });
+      test('Sets updateAnnotatedFile', () {
+        final api = Openapi(
+            inputSpec: InputSpec.json(),
+            generatorName: Generator.dart,
+            updateAnnotatedFile: false);
+        expect(api.updateAnnotatedFile, isFalse);
+      });
       group('InputSpec', () {
         group('local spec', () {
           test('provides default yaml path', () {

--- a/openapi-generator/lib/src/models/generator_arguments.dart
+++ b/openapi-generator/lib/src/models/generator_arguments.dart
@@ -47,6 +47,11 @@ class GeneratorArguments {
   /// Default: false
   final bool skipValidation;
 
+  /// Write the last run placeholder to the annotated file.
+  ///
+  /// Default: true
+  final bool updateAnnotatedFile;
+
   /// Provides an OAS spec file.
   ///
   /// When the [useNextGen] flag is set this should be the spec file configuration
@@ -104,6 +109,8 @@ class GeneratorArguments {
             annotations.readPropertyOrDefault('runSourceGenOnOutput', true),
         shouldFetchDependencies =
             annotations.readPropertyOrDefault('fetchDependencies', true),
+        updateAnnotatedFile =
+            annotations.readPropertyOrDefault('updateAnnotatedFile', true),
         outputDirectory = annotations.readPropertyOrNull('outputDirectory'),
         cachePath =
             annotations.readPropertyOrDefault('cachePath', defaultCachedPath),

--- a/openapi-generator/lib/src/openapi_generator_runner.dart
+++ b/openapi-generator/lib/src/openapi_generator_runner.dart
@@ -220,24 +220,35 @@ class OpenapiGenerator extends GeneratorForAnnotation<annots.Openapi> {
           ),
         ),
       );
-      await updateAnnotatedFile(annotatedPath: annotatedPath).then(
-        (_) => logOutputMessage(
-          log: log,
-          communication: OutputMessage(
-            message: 'Successfully updated annotated file.',
-            level: Level.CONFIG,
+      if (args.updateAnnotatedFile) {
+        await updateAnnotatedFile(annotatedPath: annotatedPath).then(
+          (_) => logOutputMessage(
+            log: log,
+            communication: OutputMessage(
+              message: 'Successfully updated annotated file.',
+              level: Level.CONFIG,
+            ),
           ),
-        ),
-        onError: (e, st) => logOutputMessage(
+          onError: (e, st) => logOutputMessage(
+            log: log,
+            communication: OutputMessage(
+              message: 'Failed to update annotated class file.',
+              level: Level.WARNING,
+              additionalContext: e,
+              stackTrace: st,
+            ),
+          ),
+        );
+      } else {
+        logOutputMessage(
           log: log,
           communication: OutputMessage(
-            message: 'Failed to update annotated class file.',
+            message:
+                'Skipped updating annotated file step because flag was set.',
             level: Level.WARNING,
-            additionalContext: e,
-            stackTrace: st,
           ),
-        ),
-      );
+        );
+      }
     }
     return '';
   }

--- a/openapi-generator/test/builder_test.dart
+++ b/openapi-generator/test/builder_test.dart
@@ -263,6 +263,27 @@ class TestClassConfig extends OpenapiGeneratorConfig {}
         copy.deleteSync();
         expect(hasOutput, isTrue);
       });
+      test('skip updating annotated file', () async {
+        final annotatedFile = File(
+            '.${Platform.pathSeparator}test${Platform.pathSeparator}specs${Platform.pathSeparator}output-nextgen${Platform.pathSeparator}annotated_file.dart');
+        final annotetedFileContent = '\n';
+        await annotatedFile.writeAsString(annotetedFileContent, flush: true);
+
+        generatedOutput = await generate('''
+@Openapi(
+  inputSpecFile: '$specPath',
+  inputSpec: RemoteSpec(path: '$specPath'),
+  useNextGen: true,
+  cachePath: '${f.path}',
+  updateAnnotatedFile: false,
+)
+          ''', path: annotatedFile.path);
+        expect(
+            generatedOutput,
+            contains(
+                'Skipped updating annotated file step because flag was set.'));
+        expect(annotatedFile.readAsStringSync(), equals(annotetedFileContent));
+      });
       group('source gen', () {
         group('uses Flutter', () {
           group('with wrapper', () {

--- a/openapi-generator/test/builder_test.dart
+++ b/openapi-generator/test/builder_test.dart
@@ -132,8 +132,8 @@ class TestClassConfig extends OpenapiGeneratorConfig {}
         'https://raw.githubusercontent.com/Nexushunter/tagmine-api/main/openapi.yaml';
     final basePath = '${testSpecPath}output-nextgen/';
     final f = File('${basePath}cache.json');
-    tearDown(() {
-      final b = File(basePath);
+    tearDownAll(() {
+      final b = Directory(basePath);
       if (b.existsSync()) b.deleteSync(recursive: true);
     });
 

--- a/openapi-generator/test/generator_arguments_test.dart
+++ b/openapi-generator/test/generator_arguments_test.dart
@@ -19,6 +19,8 @@ void main() {
       test('shouldFetchDependencies',
           () => expect(args.shouldFetchDependencies, isTrue));
       test('skipValidation', () => expect(args.skipValidation, isFalse));
+      test('updateAnnotatedFile',
+          () => expect(args.updateAnnotatedFile, isTrue));
       test(
           'pubspecPath',
           () => expect(
@@ -168,6 +170,7 @@ void main() {
         expect(args.isRemote, isFalse);
         expect(args.generatorName, 'dart-dio');
         expect(args.shouldGenerateSources, isTrue);
+        expect(args.updateAnnotatedFile, isTrue);
         expect(args.additionalProperties?.useEnumExtension, isTrue);
         expect(args.additionalProperties?.pubAuthor, 'test author');
         expect(await args.jarArgs, [
@@ -218,6 +221,7 @@ void main() {
         expect(args.isRemote, isFalse);
         expect(args.generatorName, 'dart-dio');
         expect(args.shouldGenerateSources, isTrue);
+        expect(args.updateAnnotatedFile, isTrue);
         expect(args.additionalProperties?.useEnumExtension, isTrue);
         expect((args.additionalProperties as DioProperties?)?.nullableFields,
             isTrue);
@@ -269,6 +273,7 @@ void main() {
         expect(args.isRemote, isFalse);
         expect(args.generatorName, 'dart-dio');
         expect(args.shouldGenerateSources, isTrue);
+        expect(args.updateAnnotatedFile, isTrue);
         expect(args.additionalProperties?.useEnumExtension, isTrue);
         expect(
             (args.additionalProperties as DioAltProperties?)?.nullSafe, isTrue);
@@ -329,6 +334,7 @@ void main() {
             'https://petstore3.swagger.io/api/v3/openapi.json');
         expect(args.generatorName, 'dart-dio');
         expect(args.shouldGenerateSources, isTrue);
+        expect(args.updateAnnotatedFile, isTrue);
         expect(args.additionalProperties?.useEnumExtension, isTrue);
         expect(
             (args.additionalProperties as DioAltProperties?)?.nullSafe, isTrue);

--- a/openapi-generator/test/specs/dio_alt_properties_test_config.dart
+++ b/openapi-generator/test/specs/dio_alt_properties_test_config.dart
@@ -22,5 +22,6 @@ import 'package:openapi_generator_annotations/openapi_generator_annotations.dart
       nullSafeArrayDefault: true),
   inlineSchemaNameMappings: {'200resp': 'OkResp'},
   projectPubspecPath: './test/specs/dart_pubspec.test.yaml',
+  updateAnnotatedFile: true,
 )
 class DioAltPropertiesTestConfig {}

--- a/openapi-generator/test/specs/dio_properties_test_config.dart
+++ b/openapi-generator/test/specs/dio_properties_test_config.dart
@@ -21,5 +21,6 @@ import 'package:openapi_generator_annotations/openapi_generator_annotations.dart
       nullableFields: true),
   inlineSchemaNameMappings: {'200resp': 'OkResp'},
   projectPubspecPath: './test/specs/dart_pubspec.test.yaml',
+  updateAnnotatedFile: true,
 )
 class DioPropertiesTestConfig {}

--- a/openapi-generator/test/specs/input_remote_properties_test_config.dart
+++ b/openapi-generator/test/specs/input_remote_properties_test_config.dart
@@ -23,5 +23,6 @@ import 'package:openapi_generator_annotations/openapi_generator_annotations.dart
       nullSafeArrayDefault: true),
   inlineSchemaNameMappings: {'200resp': 'OkResp'},
   projectPubspecPath: './test/specs/dart_pubspec.test.yaml',
+  updateAnnotatedFile: true,
 )
 class DioAltPropertiesTestConfig {}

--- a/openapi-generator/test/specs/test_config.dart
+++ b/openapi-generator/test/specs/test_config.dart
@@ -22,5 +22,6 @@ import 'package:openapi_generator_annotations/openapi_generator_annotations.dart
       legacyDiscriminatorBehavior: true),
   inlineSchemaNameMappings: {'200resp': 'OkResp'},
   projectPubspecPath: './test/specs/dart_pubspec.test.yaml',
+  updateAnnotatedFile: true,
 )
 class TestClassConfig {}

--- a/openapi-generator/test/test_annotations/test_configs.dart
+++ b/openapi-generator/test/test_annotations/test_configs.dart
@@ -13,6 +13,8 @@ const inputSpec = '';
 const runSourceGenOnOutput = true;
 
 const skipSpecValidation = false;
+
+const updateAnnotatedFile = true;
 ''')
 @Openapi(inputSpec: InputSpec(path: ''), generatorName: Generator.dio)
 class TestClassDefault {}
@@ -29,6 +31,8 @@ const inputSpec = '';
 const runSourceGenOnOutput = true;
 
 const skipSpecValidation = false;
+
+const updateAnnotatedFile = true;
 ''')
 @Openapi(
   inputSpec: InputSpec(path: ''),
@@ -49,6 +53,8 @@ const inputSpec = '';
 const runSourceGenOnOutput = true;
 
 const skipSpecValidation = false;
+
+const updateAnnotatedFile = true;
 ''')
 @Openapi(
   inputSpec: InputSpec(path: ''),

--- a/openapi-generator/test/test_annotations/test_generator.dart
+++ b/openapi-generator/test/test_annotations/test_generator.dart
@@ -48,6 +48,7 @@ class TestGenerator extends src_gen.GeneratorForAnnotation<Openapi> {
       SupportedFields(name: 'runSourceGenOnOutput', type: bool),
       SupportedFields(name: 'cachePath', type: String),
       SupportedFields(name: 'projectPubspecPath', type: String),
+      SupportedFields(name: 'updateAnnotatedFile', type: bool),
     ]..sort((a, b) => a.name.compareTo(b.name));
     for (final field in fields) {
       final v = annotation.read(field.name);


### PR DESCRIPTION
Fixes #131

This PR adds `updateAnnotatedFile` property to `@OpenApi()` annotation.

When the timestamp is forcibly added or updated to the `@OpenApi()` annotated class, frequent differences occur in source control. Therefore, by adding the `updateAnnotatedFile` property, if `false` is set, the addition or update of the timestamp will not be performed.

```dart
@Openapi(
  ...
  updateAnnotatedFile: false,
)
```

Default is `true` to keep current behavior.

The operation was checked by uncommenting in `openapi-generator/pubspec.yaml`.

```yaml
# dependency_overrides:
#  openapi_generator_annotations:
#    path: ../openapi-generator-annotations
```